### PR TITLE
chore: Remove unnecessary git branch tracking command

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git branch --track main origin/main
       - run: git fetch origin main
       - run: git checkout main
       - run: git pull origin main


### PR DESCRIPTION
The git branch tracking command was removed from the backport workflow in the `.github/workflows/backport.yml` file. This command is no longer needed as the workflow already fetches the latest changes from the `main` branch. This change simplifies the workflow and improves its efficiency.
